### PR TITLE
Added support for secure connections (ssl)

### DIFF
--- a/dev_config.json
+++ b/dev_config.json
@@ -2,7 +2,11 @@
     "isDev": true,
     "logLevel": 3,
     "server": {
-        "port": 8888
+        "port": 8888,
+        "secure": false, /* whether this connects via https */
+        "key": null,
+        "cert": null,
+        "password": null 
     },
     "stunservers" : [
         {"url": "stun:stun.l.google.com:19302"}

--- a/test.js
+++ b/test.js
@@ -14,10 +14,17 @@ output.on('end', function () {
 
 var io = require('socket.io-client');
 
-var socketURL = 'http://localhost:' + config.server.port;
+var socketURL;
+if (config.server.secure) {
+    socketURL = "https://localhost:" + config.server.port;
+} else {
+    socketURL = "http://localhost:" + config.server.port;
+}
+
 var socketOptions = {
     transports: ['websocket'],
-    'force new connection': true
+    'force new connection': true,
+    "secure": config.server.secure
 };
 
 test('it should not crash when sent an empty message', function (t) {


### PR DESCRIPTION
I added support for https connections.

For some reason, the test.js can't connect to the server instance via https. But it works perfectly with simplewebrtc.js. Therefore, I can use simplewebrtc now on my website which is served via https only.

Note: you can either enable serving via http or https - not both. 