### PR TITLE
allow selectively vending turn credentials depending on origin

### DIFF
--- a/sockets.js
+++ b/sockets.js
@@ -13,7 +13,7 @@ module.exports = function (server, config) {
     io.sockets.on('connection', function (client) {
         client.resources = {
             screen: false,
-            video: true,
+            video: false,
             audio: false
         };
 
@@ -109,17 +109,26 @@ module.exports = function (server, config) {
         // create shared secret nonces for TURN authentication
         // the process is described in draft-uberti-behave-turn-rest
         var credentials = [];
-        config.turnservers.forEach(function (server) {
-            var hmac = crypto.createHmac('sha1', server.secret);
-            // default to 86400 seconds timeout unless specified
-            var username = Math.floor(new Date().getTime() / 1000) + (server.expiry || 86400) + "";
-            hmac.update(username);
-            credentials.push({
-                username: username,
-                credential: hmac.digest('base64'),
-                url: server.url
+
+        // allow vending credentials based on origin.
+        var origin = null;
+        try {
+            origin = client.manager.transports[client.id].req.headers.origin;
+        } catch (e) {
+        }
+        if (!config.turnorigins || config.turnorigins.indexOf(origin) !== -1) {
+            config.turnservers.forEach(function (server) {
+                var hmac = crypto.createHmac('sha1', server.secret);
+                // default to 86400 seconds timeout unless specified
+                var username = Math.floor(new Date().getTime() / 1000) + (server.expiry || 86400) + "";
+                hmac.update(username);
+                credentials.push({
+                    username: username,
+                    credential: hmac.digest('base64'),
+                    url: server.url
+                });
             });
-        });
+        }
         client.emit('turnservers', credentials);
     });
 


### PR DESCRIPTION
this is mostly for the sandbox server so we can selectively vend TURN credentials depending on the origin (say... dev.modern.ie)