### PR TITLE
fix: Option log level is not valid. Please refer to the README.

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -1,6 +1,5 @@
 {
   "isDev": true,
-  "logLevel": 3,
   "server": {
     "port": 8888,
     "/* secure */": "/* whether this connects via https */",

--- a/config/production.json
+++ b/config/production.json
@@ -1,6 +1,5 @@
 {
   "isDev": false,
-  "logLevel": 3,
   "server": {
     "port": 8888,
     "/* secure */": "/* whether this connects via https */",

--- a/sockets.js
+++ b/sockets.js
@@ -5,11 +5,6 @@ var socketIO = require('socket.io'),
 module.exports = function (server, config) {
     var io = socketIO.listen(server);
 
-    if (config.logLevel) {
-        // https://github.com/Automattic/socket.io/wiki/Configuring-Socket.IO
-        io.set('log level', config.logLevel);
-    }
-
     io.sockets.on('connection', function (client) {
         client.resources = {
             screen: false,


### PR DESCRIPTION
This commit fixes the following error:

```
Option log level is not valid. Please refer to the README.
```

It has mentioned in #52 

To enable debug output read the socket.io docs
http://socket.io/docs/migrating-from-0-9/#log-differences

tl;dr;

```
DEBUG=* node server.js
```
