### PR TITLE
fixed socket.io to 1.3.7

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -1,6 +1,5 @@
 {
   "isDev": true,
-  "logLevel": 3,
   "server": {
     "port": 8888,
     "/* secure */": "/* whether this connects via https */",

--- a/config/production.json
+++ b/config/production.json
@@ -1,6 +1,5 @@
 {
   "isDev": false,
-  "logLevel": 3,
   "server": {
     "port": 8888,
     "/* secure */": "/* whether this connects via https */",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "getconfig": "2.1.0",
     "node-uuid": "1.2.0",
-    "socket.io": "^1.3.7",
+    "socket.io": "1.3.7",
     "yetify": "0.0.1"
   },
   "main": "server.js",

--- a/sockets.js
+++ b/sockets.js
@@ -5,11 +5,6 @@ var socketIO = require('socket.io'),
 module.exports = function (server, config) {
     var io = socketIO.listen(server);
 
-    if (config.logLevel) {
-        // https://github.com/Automattic/socket.io/wiki/Configuring-Socket.IO
-        io.set('log level', config.logLevel);
-    }
-
     io.sockets.on('connection', function (client) {
         client.resources = {
             screen: false,


### PR DESCRIPTION
caret (^) takes the latest major version of socket.io (1.4.4), which runs into errors