### PR TITLE
use node image for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM google/nodejs-runtime
+FROM node:4-onbuild


### PR DESCRIPTION
previously used image is deprecated
see #45 