### PR TITLE
Updated README to reflect name of npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ NODE_ENV=production node server.js
 
 ## Use with Express
     var express = require('express')
-    var sockets = require('signalmaster/sockets')
+    var sockets = require('signal-master/sockets')
 
     var app = express()
     var server = app.listen(port)


### PR DESCRIPTION
I noticed the npm package is `signal-master` rather than `signalmaster`. I changed the README to reflect this.