### PR TITLE
Move logic to request ice servers into factory class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 node_modules
 *.pem

--- a/config/development.json
+++ b/config/development.json
@@ -12,6 +12,7 @@
     "/* maxClients */": "/* maximum number of clients per room. 0 = no limit */",
     "maxClients": 0
   },
+  "iceController": "./iceServers",
   "stunservers": [
     {
       "url": "stun:stun.l.google.com:19302"

--- a/config/production.json
+++ b/config/production.json
@@ -12,6 +12,7 @@
     "/* maxClients */": "/* maximum number of clients per room. 0 = no limit */",
     "maxClients": 0
   },
+  "iceController": "./iceServer",
   "stunservers": [
     {
       "url": "stun:stun.l.google.com:19302"

--- a/iceServers.js
+++ b/iceServers.js
@@ -1,0 +1,31 @@
+var crypto = require('crypto');
+var config = require('getconfig');
+module.exports = {
+    getIceServers: function (client, cb) {
+        try {
+            // create shared secret nonces for TURN authentication
+            // the process is described in draft-uberti-behave-turn-rest
+            var credentials = [];
+            // allow selectively vending turn credentials based on origin.
+            var origin = client.handshake.headers.origin;
+
+            if (!config.turnorigins || config.turnorigins.indexOf(origin) !== -1) {
+                config.turnservers.forEach(function (server) {
+                    var hmac = crypto.createHmac('sha1', server.secret);
+                    // default to 86400 seconds timeout unless specified
+                    var username = Math.floor(new Date().getTime() / 1000) + (parseInt(server.expiry || 86400, 10)) + "";
+                    hmac.update(username);
+                    credentials.push({
+                        username: username,
+                        credential: hmac.digest('base64'),
+                        urls: server.urls || server.url
+                    });
+                });
+            }
+            cb(null, {turnservers: credentials, stunservers: config.stunservers || []});
+        } catch (e) {
+            cb(e, {});
+        }
+    }
+
+};

--- a/sockets.js
+++ b/sockets.js
@@ -100,27 +100,14 @@ module.exports = function (server, config) {
 
 
         // tell client about stun and turn servers and generate nonces
-        client.emit('stunservers', config.stunservers || []);
-
-        // create shared secret nonces for TURN authentication
-        // the process is described in draft-uberti-behave-turn-rest
-        var credentials = [];
-        // allow selectively vending turn credentials based on origin.
-        var origin = client.handshake.headers.origin;
-        if (!config.turnorigins || config.turnorigins.indexOf(origin) !== -1) {
-            config.turnservers.forEach(function (server) {
-                var hmac = crypto.createHmac('sha1', server.secret);
-                // default to 86400 seconds timeout unless specified
-                var username = Math.floor(new Date().getTime() / 1000) + (parseInt(server.expiry || 86400, 10)) + "";
-                hmac.update(username);
-                credentials.push({
-                    username: username,
-                    credential: hmac.digest('base64'),
-                    urls: server.urls || server.url
-                });
-            });
-        }
-        client.emit('turnservers', credentials);
+        var iceController = require(config.iceController);
+        iceController.getIceServers(client, safeCb(function (error, response) {
+            if (error) {
+                console.log('err', error);
+            }
+            client.emit('stunservers', response.stunservers || []);
+            client.emit('turnservers', response.turnservers || []);
+        }));
     });
 
 


### PR DESCRIPTION
We would like to remove the functionality use retrieve a local list of ice servers and replace the logic with factory class to allow one to retrieve a list of ice servers from any service.