### PR TITLE
Pass Socket.IO instance instead of the http server

### DIFF
--- a/sockets.js
+++ b/sockets.js
@@ -2,9 +2,7 @@ var socketIO = require('socket.io'),
     uuid = require('node-uuid'),
     crypto = require('crypto');
 
-module.exports = function (server, config) {
-    var io = socketIO.listen(server);
-
+module.exports = function (io, config) {
     io.sockets.on('connection', function (client) {
         client.resources = {
             screen: false,


### PR DESCRIPTION
It should not be hardcoded the Socket.IO instance creation, and if it's passing the http server instance just for that, instead it should be passed the io instance